### PR TITLE
correct device_class of power measurements to be power instead of energy

### DIFF
--- a/rest_ampere_storage_pro.yaml
+++ b/rest_ampere_storage_pro.yaml
@@ -28,7 +28,7 @@ sensor:
     unique_id: ampere_battery_power
     value_template: '{{ (value_json.state.split(" ")[0] | float) * -1 }}'
     unit_of_measurement: "W"
-    device_class: energy
+    device_class: power
     state_class: measurement
     scan_interval: 15
 
@@ -39,7 +39,7 @@ sensor:
     unique_id: ampere_powermeter_realPower
     value_template: '{{ value_json.state | regex_replace("([^\d.]+)","") | float }}'
     unit_of_measurement: "W"
-    device_class: energy
+    device_class: power
     state_class: measurement
     scan_interval: 15
 
@@ -50,7 +50,7 @@ sensor:
     unique_id: ampere_inverter_pvPower
     value_template: '{{ value_json.state | regex_replace("([^\d.]+)","") | float }}'
     unit_of_measurement: "W"
-    device_class: energy
+    device_class: power
     state_class: measurement
     scan_interval: 15
 


### PR DESCRIPTION
Thanks a lot for putting in the effort to create this!
When using your integration though, my HomeAssistant complained about wrong device_classes. Watts are not a unit of energy but rather a unit of power, thus I corrected the sensors of your integration accordingly.